### PR TITLE
Bugfix/properly initialize chai should assertion style

### DIFF
--- a/lib/generators/app/index.js
+++ b/lib/generators/app/index.js
@@ -8,12 +8,6 @@ var MochaGenerator = module.exports = function MochaGenerator(args, options) {
   yeoman.generators.Base.apply(this, arguments);
   this.sourceRoot(path.join(__dirname, '../../', 'templates'));
 
-  this.option('assert-style', {
-    desc: 'Choose the asssert style you wish to use (assert, expect, should). Only enabled with chai.',
-    type: String,
-    defaults: 'expect'
-  });
-
   this.option('ui', {
     desc: 'Choose your style of DSL (bdd, tdd, qunit, or exports)',
     type: String,

--- a/lib/templates/index.html
+++ b/lib/templates/index.html
@@ -11,7 +11,11 @@
     <script src="bower_components/mocha/mocha.js"></script>
     <script>mocha.setup('<%= (options.ui) %>')</script>
     <script src="bower_components/chai/chai.js"></script>
-    <script>var <%= options['assert-style'] %> = chai.<%= options['assert-style'] %></script>
+    <script>
+        var assert = chai.assert;
+        var expect = chai.expect;
+        var should = chai.should();
+    </script>
 
     <!-- include source files here... -->
 


### PR DESCRIPTION
Remove 'assertion-style' as it did not properly initialize the 'should' style. Initialize the three Chai styles: assert, expect, should. 'should' is kept as a variable so one could assert `should.exist(subject);`
