### PR TITLE
Make sure Bower components go where they are expected

### DIFF
--- a/lib/generators/app/index.js
+++ b/lib/generators/app/index.js
@@ -27,6 +27,7 @@ util.inherits(MochaGenerator, yeoman.generators.Base);
 
 MochaGenerator.prototype.setupEnv = function setupEnv() {
   this.copy('_bower.json', 'test/bower.json');
+  this.copy('bowerrc', 'test/.bowerrc');
   this.copy('test.js', 'test/spec/test.js');
   this.copy('index.html', 'test/index.html');
 };

--- a/lib/templates/bowerrc
+++ b/lib/templates/bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "bower_components"
+}


### PR DESCRIPTION
The test index.html assumes bower components will be in `./bower_components`.  If other generators include .bowerrc files (e.g. generator-webapp), this may not end up being the Bower components directory.  An alternative to this would be to use Bower's own logic to determine the path to the components directory before processing the index.html template.
