### PR TITLE
JSHint: remove ES5, hide script url warning in test, wrap use strict in test template

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,6 @@
   "camelcase": true,
   "curly": true,
   "eqeqeq": true,
-  "es5": true,
   "esnext": true,
   "immed": true,
   "indent": 2,

--- a/lib/templates/test.js
+++ b/lib/templates/test.js
@@ -1,7 +1,8 @@
-/*global describe, it */
-'use strict';
+/* global describe, it */
 
 (function () {
+    'use strict';
+
     describe('Give it some context', function () {
         describe('maybe a bit more context here', function () {
             it('should run here few assertions', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-/*global describe, beforeEach, it */
+/* global describe, beforeEach, it */
 'use strict';
 
 var path = require('path');
@@ -11,9 +11,11 @@ describe('Mocha generator test', function () {
         return done(err);
       }
 
+      /* jshint -W107 */
       this.app = helpers.createGenerator('mocha:app', [
         '../../lib/generators/app'
       ]);
+      /* jshint +W107 */
       done();
     }.bind(this));
   });


### PR DESCRIPTION
- Remove ES5 option from project jshintrc as it's now set per default
- Hide script url warning (W107) in test/test.js to make jshint happy about finding `mocha` in the file
- Move `'use strict';` inside the wrapping function in the test template, to make jshint happy when the template is used in projects that have no `node: true` set
- Some whitespace fixes
