### PR TITLE
Update npm and bower package versions

### DIFF
--- a/lib/templates/_bower.json
+++ b/lib/templates/_bower.json
@@ -2,8 +2,8 @@
   "name": "<%= _.slugify(appname) %>",
   "version": "0.0.0",
   "dependencies": {
-    "chai": "~1.7.2",
-    "mocha": "~1.12.0"
+    "chai": "~1.8.0",
+    "mocha": "~1.14.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "test": "mocha --reporter spec"
   },
   "dependencies": {
-    "yeoman-generator": "~0.13.0"
+    "yeoman-generator": "~0.14.0"
   },
   "devDependencies": {
-    "mocha": "~1.12.0"
+    "mocha": "~1.14.0"
   },
   "peerDependencies": {
     "yo": ">=1.0.0-rc.1.1"


### PR DESCRIPTION
Update the following npm and bower packages to new major versions:
- chai 1.7 -> 1.8
- mocha 1.12 -> 1.14
- yeoman-generator 1.13 -> 1.14
