### PR TITLE
Remove version, add private to bower.json template

### DIFF
--- a/lib/templates/_bower.json
+++ b/lib/templates/_bower.json
@@ -1,6 +1,6 @@
 {
   "name": "<%= _.slugify(appname) %>",
-  "version": "0.0.0",
+  "private": true,
   "dependencies": {
     "chai": "~1.7.2",
     "mocha": "~1.12.0"


### PR DESCRIPTION
Set the private property in bower.json and remove the optional version property, as the bower config file is used for the spec runner and is not intended to be published in the bower package registry.
