### PR TITLE
Remove Chrome Frame meta tag from index template

### DIFF
--- a/lib/templates/index.html
+++ b/lib/templates/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Mocha Spec Runner</title>
     <link rel="stylesheet" href="bower_components/mocha/mocha.css">
 </head>


### PR DESCRIPTION
Chrome Frame has been retired https://developers.google.com/chrome/chrome-frame/ . See also similar commit in HTML5 Boilerplate project https://github.com/h5bp/html5-boilerplate/commit/8fc26501f4635df92bbbff966d8d6e6064e0e419
