### PR TITLE
Use 2 spaces for indentation

### DIFF
--- a/generators/app/templates/test.js
+++ b/generators/app/templates/test.js
@@ -1,13 +1,13 @@
 /* global describe, it */
 
 (function () {
-    'use strict';
+  'use strict';
 
-    describe('Give it some context', function () {
-        describe('maybe a bit more context here', function () {
-            it('should run here few assertions', function () {
+  describe('Give it some context', function () {
+    describe('maybe a bit more context here', function () {
+      it('should run here few assertions', function () {
 
-            });
-        });
+      });
     });
+  });
 })();


### PR DESCRIPTION
Not sure if this will screw up generators which still use 4 spaces.

This fixes yeoman/generator-webapp#418.
