### PR TITLE
Adding wiredep block

### DIFF
--- a/generators/app/templates/index.html
+++ b/generators/app/templates/index.html
@@ -16,6 +16,9 @@
         var should = chai.should();
     </script>
 
+    <!-- bower:js -->
+    <!-- endbower -->
+
     <!-- include source files here... -->
 
     <!-- include spec files here... -->


### PR DESCRIPTION
This will help me to add backbone and its dependencies into `test/index.html` from backbone generator.

backbone generator will below config this to generated `Gruntfile.js`

``` js
        wiredep: {
            test: {
                src: [
                    'test/index.html'
                ],
                options: {
                    ignorePath: '../app/'
                }
            }
        }
```
