### PR TITLE
Added main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "tdd",
     "mocha"
   ],
+  "main": "generators/app/index.js",
   "author": "The Yeoman Team",
   "repository": "yeoman/generator-mocha",
   "scripts": {


### PR DESCRIPTION
While using the yeoman programatic api I couldn't resolve `generator-mocha` automatically, turns out that it was just the missing `main` property.

I guess it should be there as it seems to be the norm with all the other official generators.
