### PR TITLE
avoid no necessary mocha.run()

### DIFF
--- a/generators/app/templates/index.html
+++ b/generators/app/templates/index.html
@@ -24,6 +24,17 @@
     <!-- include spec files here... -->
     <script src="spec/test.js"></script>
 
-    <script>mocha.run()</script>
+    <!-- run mocha after all test are loaded -->
+    <script>
+
+        /*
+         * Only tests run in real browser, if grunt-mocha options.run == true
+         * the injected js by grunt-mocha will execute mocha.run() when everything has been done
+         * add this if conditions to avoid no necessary mocha.run()
+         */
+        if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+            mocha.run();
+        }
+    </script>
 </body>
 </html>

--- a/generators/app/templates/index.html
+++ b/generators/app/templates/index.html
@@ -32,7 +32,7 @@
          * the injected js by grunt-mocha will execute mocha.run() when everything has been done
          * add this if conditions to avoid no necessary mocha.run()
          */
-        if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+        if (navigator.userAgent.indexOf('PhantomJS') === -1) {
             mocha.run();
         }
     </script>


### PR DESCRIPTION
Only tests run in real browser, if grunt-mocha options.run == true, the injected js by grunt-mocha will execute mocha.run() when everything has been done, add this if conditions to avoid no necessary mocha.run().

why I said the previous mocha.run() is not necessary. Because we all know that: 
`grunt-mocha injects a script into the PhantomJS instance that loads your HTML spec files. The file sets up a reporter and listeners so the output can be output in the command line. This option will call mocha.run() after the script is injected, ensuring that the proper listeners are setup.`

the injected script's position is below the previous mocha.run(), so when the mocha.run() is executed, the relative grunt listeners are not ready, on the console we will not receive the test report. eventually the injected js run mocha.run() again, which have us the console test case report.