### PR TITLE
Updated directory of bower for newest version

### DIFF
--- a/generators/app/templates/index.html
+++ b/generators/app/templates/index.html
@@ -3,19 +3,19 @@
 <head>
   <meta charset="utf-8">
   <title>Mocha Spec Runner</title>
-  <link rel="stylesheet" href="/bower_components/mocha/mocha.css">
+  <link rel="stylesheet" href="../bower_components/mocha/mocha.css">
 </head>
 <body>
   <div id="mocha"></div>
-  <script src="/bower_components/mocha/mocha.js"></script>
+  <script src="../bower_components/mocha/mocha.js"></script>
   <script>mocha.setup('<%= (options.ui) %>');</script>
-  <script src="/bower_components/chai/chai.js"></script>
+  <script src="../bower_components/chai/chai.js"></script>
   <script>
     var assert = chai.assert;
     var expect = chai.expect;
     var should = chai.should();
   </script><% if (options.rjs) { %>
-  <script src="/bower_components/requirejs/require.js"></script>
+  <script src="../bower_components/requirejs/require.js"></script>
   <script>
     require([
       // include spec files here


### PR DESCRIPTION
Hi all,
I've noticed after installing 0.1.8, all bower_components are installed in the parent directory, rather than within the /test directory (since the removal of the bower.json and bowerrc, etc) . This causes problems when trying to the run the tests, as the index.html file is referencing a bower_components folder that doesn't exist.

